### PR TITLE
Update menu.es.toml

### DIFF
--- a/config/_default/menu/menu.es.toml
+++ b/config/_default/menu/menu.es.toml
@@ -5,7 +5,7 @@
     weight = 1
     
 [[main]]
-    name = "Sobre nosotros"
+    name = "Sobre R-Ladies"
     url = "#"
     identifier = "about-us"
     weight = 2


### PR DESCRIPTION
I would avoid "nosotros" which means us, because in Spanish you can also say "nosotras" which mens us but feminin. Currently many people discuss wether to visibilize women and gender diversities using "nosotres" (for men, women and gender diversities) should be used, but this is still not oficially accepted and not everyone likes that or uses that term. So I would just avoid using it and replacing it by "Sobre R-Ladies" which literaly means "about R-Ladies" intead of "about us".