### PR TITLE
remove null roles; to solve GH actions error

### DIFF
--- a/data/global_team/alumni/cosima-meyer.json
+++ b/data/global_team/alumni/cosima-meyer.json
@@ -1,6 +1,6 @@
 {
   "name": "Cosima Meyer",
-  "role": [null],
+  "role": ["Website"],
   "start": "2023-06-01",
   "end": "2025-07-22",
   "img": {

--- a/data/global_team/alumni/sara-acevedo.json
+++ b/data/global_team/alumni/sara-acevedo.json
@@ -1,6 +1,6 @@
 {
   "name": "Sara Acevedo",
-  "role": [null],
+  "role": ["CoC Enforcement Support"],
   "start": "2023-06-01",
   "end": "2025-07-22",
   "img": {


### PR DESCRIPTION
There is an error with GitHub Actions when the role is `null` or without quotes. 

<img width="1019" height="566" alt="Screenshot 2025-12-13 at 9 41 12 AM" src="https://github.com/user-attachments/assets/ed91bd62-7056-49ae-93bf-6b4cc14e6422" />
