### PR TITLE
Update social media links for R Ladies Remote

### DIFF
--- a/data/chapters/worldwide-remote.json
+++ b/data/chapters/worldwide-remote.json
@@ -5,9 +5,10 @@
   "city": "Remote",
   "social_media": {
     "meetup": "rladies-remote",
-    "twitter": "rladiesremote",
+    "bluesky": "https://bsky.app/profile/rladiesremote.bsky.social",
+    "mastodon": "https://hachyderm.io/@RLadiesRemote",
     "email": "remote@rladies.org",
-    "slack": "https://rladies-remote.slack.com"
+    "slack": "https://twitter.us18.list-manage.com/subscribe?u=2ea47051e532678beaba00ee9&id=0d53e23281"
   },
   "organizers": {
     "current": [


### PR DESCRIPTION
Also replace direct slack link to sign-up page with background information on the group.

cc @LucyNjoki.