### PR TITLE
Update social media information for Santa Rosa (La Pampa, Argentina)

### DIFF
--- a/data/chapters/argentina-la-pampa-santa-rosa.json
+++ b/data/chapters/argentina-la-pampa-santa-rosa.json
@@ -6,9 +6,7 @@
   "city": "Santa Rosa",
   "social_media": {
     "meetup": "rladies-santa-rosa",
-    "twitter": "RladiesSR",
     "email": "santarosa@rladies.org",
-    "facebook": "RLadiesSR",
     "github": "rladies/meetup-presentations_santarosa"
   },
   "organizers": {


### PR DESCRIPTION
Removed Twitter and Facebook handles from social media section.