### PR TITLE
Add ROR identifier and JSON-LD structured data

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -1,5 +1,6 @@
 name: R-Ladies Global
 email: 'info[at]rladies[dot]org'
+ror: 'https://ror.org/05wpb1k41'
 avatar: images/logo.png
 avatarclass: rounded
 year: 2013

--- a/themes/hugo-rladies/layouts/partials/head/head.html
+++ b/themes/hugo-rladies/layouts/partials/head/head.html
@@ -16,5 +16,8 @@
 <!-- site data -->
 {{ partial "head/data.html" . }}
 
+<!-- structured data -->
+{{ partial "head/jsonld.html" . }}
+
 <!-- plausible -->
 <script defer data-domain="rladies.org" src="https://plausible.io/js/script.js"></script>

--- a/themes/hugo-rladies/layouts/partials/head/jsonld.html
+++ b/themes/hugo-rladies/layouts/partials/head/jsonld.html
@@ -1,0 +1,34 @@
+{{ if .IsHome }}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "R-Ladies Global",
+  "alternateName": ["RLadies Global", "RLadies+ Global"],
+  "url": "https://rladies.org",
+  "logo": "{{ "images/logo.png" | absURL }}",
+  "description": "{{ .Site.Params.description }}",
+  "foundingDate": "2012",
+  "identifier": [
+    {
+      "@type": "PropertyValue",
+      "propertyID": "ROR",
+      "value": "https://ror.org/05wpb1k41"
+    },
+    {
+      "@type": "PropertyValue",
+      "propertyID": "Wikidata",
+      "value": "Q71297539"
+    }
+  ],
+  "sameAs": [
+    "https://www.wikidata.org/wiki/Q71297539",
+    "https://github.com/rladies",
+    "https://www.linkedin.com/company/rladies",
+    "https://bsky.app/profile/rladies.org",
+    "https://hachyderm.io/@RLadiesGlobal",
+    "https://www.youtube.com/channel/UCDgj5-mFohWZ5irWSFMFcng"
+  ]
+}
+</script>
+{{ end }}


### PR DESCRIPTION
## Summary
- Add R-Ladies Global ROR ID (`https://ror.org/05wpb1k41`) to site params
- Create Schema.org Organization JSON-LD with ROR and Wikidata identifiers on the homepage
- Improves search engine discoverability and links to authoritative identifiers

## Test plan
- [ ] Verify site builds without errors
- [ ] Check homepage source for JSON-LD script block
- [ ] Validate JSON-LD at https://search.google.com/test/rich-results

🤖 Generated with [Claude Code](https://claude.com/claude-code)