### PR TITLE
Skip bot accounts in hello workflow greeting

### DIFF
--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -20,12 +20,19 @@ jobs:
 
       - name: Check team membership
         id: check
+        env:
+          AUTHOR: ${{ steps.author.outputs.login }}
         run: |
-          status=$(curl -s \
+          if [[ "$AUTHOR" == *"[bot]" ]]; then
+            echo "say_hello=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          status=$(curl -sg \
             -o /dev/null -w "%{http_code}" \
             -H "Authorization: Bearer ${{ secrets.GLOBAL_GHA_PAT }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/orgs/rladies/teams/global/memberships/${{ steps.author.outputs.login }}")
+            "https://api.github.com/orgs/rladies/teams/global/memberships/$AUTHOR")
 
           if [[ "$status" != "200" ]]; then
             echo "say_hello=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- The `Hello on PR or Issue` workflow has been failing on every dependabot PR because `curl` interprets the `[bot]` in `dependabot[bot]` as a URL glob pattern (curl exit 3 = malformed URL).
- Bots shouldn't get a "hello, thanks for opening this" greeting anyway, so the fix is to short-circuit on `*[bot]` logins before the membership API call.
- Also moves the login into an env var (avoids shell-context interpolation in `pull_request_target`) and adds `-g` to curl as defence-in-depth.

## Test plan
- [ ] Workflow runs cleanly on this PR (human author → either greeted or skipped via team membership, no curl error)
- [ ] Next dependabot PR does not fail the Hello workflow and does not get greeted

🤖 Generated with [Claude Code](https://claude.com/claude-code)