### PR TITLE
Block internal broken links and absolute self-links in CI

### DIFF
--- a/.github/workflows/blog-lint.yaml
+++ b/.github/workflows/blog-lint.yaml
@@ -1,12 +1,11 @@
-name: "Blog post lint"
+name: "Content lint"
 
 on:
   pull_request:
     branches:
       - main
     paths:
-      - "content/blog/**/index*.md"
-      - "content/news/**/index*.md"
+      - "content/**/*.md"
 
 jobs:
   lint:
@@ -164,3 +163,63 @@ jobs:
             echo "::error::Blog post frontmatter has errors — see PR comment."
             exit 1
           fi
+
+  self-links:
+    name: Self-link check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Forbid absolute rladies.org self-links in changed content
+        run: |
+          cat > selflinks.js << 'SCRIPT'
+          const fs = require('fs');
+          const { execSync } = require('child_process');
+
+          const diff = execSync(
+            'git diff --unified=0 origin/main...HEAD -- "content/**/*.md"'
+          ).toString();
+
+          // Match https?://[www.]rladies.org/<path-with-something-after-slash>
+          // Allow bare https://rladies.org and https://rladies.org/ (homepage).
+          // Skip subdomains (guide., bsky., weare., etc.) — those are separate sites.
+          const selfLink = /https?:\/\/(?:www\.)?rladies\.org\/[A-Za-z0-9]/;
+
+          const findings = [];
+          let currentFile = null;
+          let currentLine = 0;
+          for (const line of diff.split('\n')) {
+            if (line.startsWith('+++ b/')) {
+              currentFile = line.slice(6);
+              continue;
+            }
+            const hunk = line.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+            if (hunk) { currentLine = parseInt(hunk[1], 10); continue; }
+            if (line.startsWith('+') && !line.startsWith('+++')) {
+              const text = line.slice(1);
+              if (selfLink.test(text)) {
+                findings.push({ file: currentFile, line: currentLine, text: text.trim() });
+              }
+              currentLine++;
+            } else if (!line.startsWith('-') && !line.startsWith('\\')) {
+              currentLine++;
+            }
+          }
+
+          if (findings.length === 0) {
+            console.log('No absolute rladies.org self-links found in changed content.');
+            process.exit(0);
+          }
+
+          console.log('::error::Use root-relative paths (e.g. /news/2025/announcement/) instead of https://rladies.org/... for internal links.');
+          for (const f of findings) {
+            const snippet = f.text.length > 120 ? f.text.slice(0, 117) + '...' : f.text;
+            console.log(`::error file=${f.file},line=${f.line}::${snippet}`);
+          }
+          process.exit(1);
+          SCRIPT
+
+          node selflinks.js

--- a/.github/workflows/lighthouse.yaml
+++ b/.github/workflows/lighthouse.yaml
@@ -398,6 +398,28 @@ jobs:
               });
             }
 
+      - name: Fail on internal broken links
+        run: |
+          if [ ! -f lychee-report.md ]; then
+            echo "No lychee report — skipping internal-link gate."
+            exit 0
+          fi
+
+          # Internal failure = error on a root-relative path, a file:// URL,
+          # or any URL on the rladies.org host (production self-references).
+          internal=$(grep -E '\[(ERR|TIMEOUT)\]' lychee-report.md | \
+            grep -E '(\[(ERR|TIMEOUT)\] (file://|/[^/])|rladies\.org)' || true)
+
+          if [ -n "$internal" ]; then
+            echo "::error::Internal links are broken on the PR build:"
+            echo "$internal" | while IFS= read -r line; do
+              echo "::error::${line}"
+            done
+            exit 1
+          fi
+
+          echo "No internal broken links."
+
   bundle-size:
     name: Bundle size
     needs: build


### PR DESCRIPTION
Closes #574.

## Summary

Two complementary CI checks so the failure mode behind #572 (a 404 internal link merging silently) fails next time:

- **`lighthouse.yaml`** — keep lychee with `fail: false` so flaky external sites don't break CI, but add a step that parses the lychee report and fails when an `[ERR]`/`[TIMEOUT]` is on a **root-relative path**, **`file://`** URL, or any **`rladies.org`** host (production self-reference).
- **`blog-lint.yaml`** (renamed `Blog post lint` → `Content lint`, scope broadened to `content/**/*.md`) — adds a `self-links` job that scans **added lines in the PR diff** for absolute `https?://[www.]rladies.org/<path>` and rejects them with a fix suggestion. Pre-existing absolute self-links in old content are intentionally left alone; only newly-authored ones are blocked.

## Why this shape

- **Diff-scoped self-link lint.** Old blog posts (e.g. 2018 history posts, 2020 meetup CSVs) contain absolute `rladies.org/...` URLs. Retroactively rewriting them is out of scope. The check only fires on lines added by the PR.
- **Subdomains pass.** `guide.rladies.org`, `bsky.app/profile/weare.rladies.org`, etc. are separate sites — not flagged.
- **Bare homepage passes.** `https://rladies.org` and `https://rladies.org/` are allowed (no path to mismatch).
- **Internal-only failure gate for lychee.** Flipping `fail: true` outright would break CI on any third-party 4xx, including transient ones; this approach blocks only when the broken link is something we control.

## Test plan

- [x] YAML syntax validated locally with `yq`.
- [x] Internal-link grep regex tested against synthetic lychee output (matches root-relative + `rladies.org`, ignores external `example.com` ERR/TIMEOUT).
- [x] Self-link regex unit-tested against 8 cases (path, subdomain, mailto, bare homepage, etc.).
- [ ] Confirm both jobs run green on this PR (no content changes here, no internal breaks expected).
- [ ] Spot-check on a follow-up content PR that introduces an `https://rladies.org/foo/` link → should fail `Self-link check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)