### PR TITLE
Set up All Contributors bot and first-merge thanks

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,16 @@
+{
+  "projectName": "rladies.github.io",
+  "projectOwner": "rladies",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "angular",
+  "commitType": "docs",
+  "contributorsPerLine": 7,
+  "contributors": [],
+  "contributorsSortAlphabetically": true
+}

--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -1,12 +1,13 @@
 name: Hello on PR or Issue
 on:
   pull_request_target:
-    types: [opened]
+    types: [opened, closed]
   issues:
     types: [opened]
 
 jobs:
-  comment:
+  hello:
+    if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
       - name: Get author
@@ -51,4 +52,39 @@ jobs:
               repo: context.repo.repo,
               issue_number: number,
               body: 'Hello! :wave:\n\nThanks for opening this. We are a volunteer organisation, but we will get back to you as soon as we can.'
+            });
+
+  thanks_first_merge:
+    if: github.event_name == 'pull_request_target' && github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check first merged PR
+        id: check
+        env:
+          AUTHOR: ${{ github.event.pull_request.user.login }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [[ "$AUTHOR" == *"[bot]" ]]; then
+            echo "thank=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          count=$(gh pr list --repo "$REPO" --author "$AUTHOR" --state merged --json number --jq 'length')
+          if [[ "$count" == "1" ]]; then
+            echo "thank=true" >> $GITHUB_OUTPUT
+          else
+            echo "thank=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Comment thanks
+        if: steps.check.outputs.thank == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: ':tada: Congratulations on your first merged pull request to the R-Ladies+ website! Thank you so much for contributing — we hope to see you back. :purple_heart:\n\nIf you have not already been added, a maintainer can recognise your contribution by commenting: `@all-contributors please add @' + context.payload.pull_request.user.login + ' for code` (or other [contribution type](https://allcontributors.org/docs/en/emoji-key)).'
             });

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 <!-- badges: start -->
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/3bf48c17-2bd3-4452-83cb-0ac808ad745b/deploy-status)](https://app.netlify.com/sites/rladies-dev/deploys)
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![All Contributors](https://img.shields.io/github/all-contributors/rladies/rladies.github.io?color=ee8449&style=flat-square)](#contributors)
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 <!-- badges: end -->
 
@@ -46,3 +49,25 @@ O --> P[Deploy Netlify]
 P --> Q["Notify PR about build"]
 
 ```
+
+## Contributors
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://allcontributors.org) specification. Contributions of any kind welcome!
+
+To add yourself or someone else as a contributor, comment on an issue or PR with:
+
+```
+@all-contributors please add @username for code, doc, design
+```
+
+See the [emoji key](https://allcontributors.org/docs/en/emoji-key) for the full list of contribution types.


### PR DESCRIPTION
## Summary

- Adds `.all-contributorsrc` and an All Contributors badge + `## Contributors` section to `README.md`, so the [All Contributors GitHub App](https://github.com/apps/allcontributors) can be used to acknowledge non-code contributions.
- Extends `.github/workflows/hello.yaml` with a `thanks_first_merge` job that posts a congrats comment when a contributor's first PR is merged, nudging maintainers to record the contribution via the bot.

Closes #428
Closes #427

## Why this approach for #427

We considered installing [behaviorbot/welcome](https://github.com/behaviorbot/welcome), but the existing `hello.yaml` workflow already greets new issue/PR authors. Adding the bot would either duplicate comments or require ripping the workflow out. Extending `hello.yaml` keeps the greeting logic in one workflow we control, and adds the one piece behaviorbot offers that we did not have: a thanks message on first merged PR.

## Admin follow-up needed before merge takes full effect

1. Install the [All Contributors GitHub App](https://github.com/apps/allcontributors) on `rladies/rladies.github.io` — the `.all-contributorsrc` file alone does nothing without the app.
2. After merge, recognise contributors by commenting `@all-contributors please add @username for code, doc` (etc.) on any issue or PR. See the [emoji key](https://allcontributors.org/docs/en/emoji-key) for contribution types.

## Test plan

- [ ] Install the All Contributors GitHub App on the repo
- [ ] After merge, test the bot by adding a known contributor via `@all-contributors please add @user for ...` and confirm a PR is opened that fills in the README marker block
- [ ] Open a test PR from a non-team-member account to verify the existing hello message still fires
- [ ] Merge a PR from a first-time contributor (or a sock-puppet test account) and confirm the thanks message posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)