### PR TITLE
renable directory shuffle

### DIFF
--- a/themes/hugo-rladiesplus/layouts/directory/list.html
+++ b/themes/hugo-rladiesplus/layouts/directory/list.html
@@ -1,6 +1,6 @@
 {{ define "head" }}{{ partial "head/choices-css.html" . }}{{ end }}
 {{ define "main" }}
-{{ $directory := .Pages }}
+{{ $directory := .Pages | shuffle }}
 {{ $paginator := .Paginate $directory 60 }}
 
 {{ $ints := slice }}


### PR DESCRIPTION
Now that directory is paginated, shuffle doesnt work as expected. this fixes that by shuffling the pages before providing information to pagination.
