### PR TITLE
Add shared pagination partial with condensed page list

### DIFF
--- a/themes/hugo-rladiesplus/assets/css/components/darkmode.css
+++ b/themes/hugo-rladiesplus/assets/css/components/darkmode.css
@@ -134,8 +134,14 @@
   }
 
   /* ── Pagination ── */
-  .dark .page-item.disabled .page-link {
+  .dark .page-link:hover {
+    background-color: var(--color-raised);
+  }
+
+  .dark .page-item.disabled .page-link,
+  .dark .page-item.disabled .page-link:hover {
     @apply text-gray-500;
+    background-color: transparent;
   }
 
   /* ── Calendar (FullCalendar) ── */

--- a/themes/hugo-rladiesplus/layouts/_default/list.html
+++ b/themes/hugo-rladiesplus/layouts/_default/list.html
@@ -36,33 +36,7 @@
       {{ end }}
     </div>
 
-    {{ if gt .Paginator.TotalPages 1 }}
-      <nav aria-label="Page navigation" class="mt-16">
-        <ul class="pagination justify-center">
-          {{ if .Paginator.HasPrev }}
-            <li class="page-item">
-              <a class="page-link" href="{{ .Paginator.Prev.URL }}" aria-label="Previous">
-                <i class="fas fa-chevron-left"></i>
-              </a>
-            </li>
-          {{ end }}
-
-          {{ range .Paginator.Pagers }}
-            <li class="page-item {{ if eq . $.Paginator }}active{{ end }}">
-              <a class="page-link" href="{{ .URL }}">{{ .PageNumber }}</a>
-            </li>
-          {{ end }}
-
-          {{ if .Paginator.HasNext }}
-            <li class="page-item">
-              <a class="page-link" href="{{ .Paginator.Next.URL }}" aria-label="Next">
-                <i class="fas fa-chevron-right"></i>
-              </a>
-            </li>
-          {{ end }}
-        </ul>
-      </nav>
-    {{ end }}
+    {{ partial "pagination.html" (dict "paginator" .Paginator) }}
   </div>
 </section>
 

--- a/themes/hugo-rladiesplus/layouts/directory/list.html
+++ b/themes/hugo-rladiesplus/layouts/directory/list.html
@@ -155,33 +155,7 @@
       {{ i18n "no_results" | default "No members match your filters." }}
     </p>
 
-    {{ if gt $paginator.TotalPages 1 }}
-      <nav id="directory-pagination" aria-label="Page navigation" class="mt-16">
-        <ul class="pagination justify-center">
-          {{ if $paginator.HasPrev }}
-            <li class="page-item">
-              <a class="page-link" href="{{ $paginator.Prev.URL }}" aria-label="Previous">
-                <i class="fas fa-chevron-left"></i>
-              </a>
-            </li>
-          {{ end }}
-
-          {{ range $paginator.Pagers }}
-            <li class="page-item {{ if eq . $paginator }}active{{ end }}">
-              <a class="page-link" href="{{ .URL }}">{{ .PageNumber }}</a>
-            </li>
-          {{ end }}
-
-          {{ if $paginator.HasNext }}
-            <li class="page-item">
-              <a class="page-link" href="{{ $paginator.Next.URL }}" aria-label="Next">
-                <i class="fas fa-chevron-right"></i>
-              </a>
-            </li>
-          {{ end }}
-        </ul>
-      </nav>
-    {{ end }}
+    {{ partial "pagination.html" (dict "paginator" $paginator "id" "directory-pagination") }}
   </div>
 </div>
 

--- a/themes/hugo-rladiesplus/layouts/partials/pagination.html
+++ b/themes/hugo-rladiesplus/layouts/partials/pagination.html
@@ -1,0 +1,50 @@
+{{/*
+  Pagination — condenses long page lists to: first 2, last 2, current ±1,
+  with ellipsis fillers. Renders nothing when there's only one page.
+
+  Params (passed as a dict):
+    paginator (required) — a Hugo Paginator (e.g. .Paginator or a custom .Paginate result)
+    id        (optional) — id attribute for the <nav> wrapper
+    class     (optional) — class for the <nav>, defaults to "mt-16"
+*/}}
+{{ $paginator := .paginator }}
+{{ $id := .id }}
+{{ $class := .class | default "mt-16" }}
+
+{{ if gt $paginator.TotalPages 1 }}
+  <nav{{ with $id }} id="{{ . }}"{{ end }} aria-label="Page navigation" class="{{ $class }}">
+    <ul class="pagination justify-center">
+      {{ if $paginator.HasPrev }}
+        <li class="page-item">
+          <a class="page-link" href="{{ $paginator.Prev.URL }}" aria-label="Previous">
+            <i class="fas fa-chevron-left"></i>
+          </a>
+        </li>
+      {{ end }}
+
+      {{ $currentPage := $paginator.PageNumber }}
+      {{ $totalPages := $paginator.TotalPages }}
+
+      {{ range $paginator.Pagers }}
+        {{ $pageNum := .PageNumber }}
+        {{ if or (le $pageNum 2) (ge $pageNum (sub $totalPages 1)) (and (ge $pageNum (sub $currentPage 1)) (le $pageNum (add $currentPage 1))) }}
+          <li class="page-item {{ if eq . $paginator }}active{{ end }}">
+            <a class="page-link" href="{{ .URL }}">{{ .PageNumber }}</a>
+          </li>
+        {{ else if or (eq $pageNum 3) (eq $pageNum (sub $totalPages 2)) }}
+          <li class="page-item disabled">
+            <span class="page-link">&hellip;</span>
+          </li>
+        {{ end }}
+      {{ end }}
+
+      {{ if $paginator.HasNext }}
+        <li class="page-item">
+          <a class="page-link" href="{{ $paginator.Next.URL }}" aria-label="Next">
+            <i class="fas fa-chevron-right"></i>
+          </a>
+        </li>
+      {{ end }}
+    </ul>
+  </nav>
+{{ end }}

--- a/themes/hugo-rladiesplus/layouts/post/list.html
+++ b/themes/hugo-rladiesplus/layouts/post/list.html
@@ -13,43 +13,7 @@
       {{ end }}
     </div>
 
-    {{ if gt .Paginator.TotalPages 1 }}
-      <nav aria-label="Page navigation" class="mt-16">
-        <ul class="pagination justify-center">
-          {{ if .Paginator.HasPrev }}
-            <li class="page-item">
-              <a class="page-link" href="{{ .Paginator.Prev.URL }}" aria-label="Previous">
-                <i class="fas fa-chevron-left"></i>
-              </a>
-            </li>
-          {{ end }}
-
-          {{ $currentPage := .Paginator.PageNumber }}
-          {{ $totalPages := .Paginator.TotalPages }}
-
-          {{ range .Paginator.Pagers }}
-            {{ $pageNum := .PageNumber }}
-            {{ if or (le $pageNum 2) (ge $pageNum (sub $totalPages 1)) (and (ge $pageNum (sub $currentPage 1)) (le $pageNum (add $currentPage 1))) }}
-              <li class="page-item {{ if eq . $.Paginator }}active{{ end }}">
-                <a class="page-link" href="{{ .URL }}">{{ .PageNumber }}</a>
-              </li>
-            {{ else if or (eq $pageNum 3) (eq $pageNum (sub $totalPages 2)) }}
-              <li class="page-item disabled">
-                <span class="page-link">&hellip;</span>
-              </li>
-            {{ end }}
-          {{ end }}
-
-          {{ if .Paginator.HasNext }}
-            <li class="page-item">
-              <a class="page-link" href="{{ .Paginator.Next.URL }}" aria-label="Next">
-                <i class="fas fa-chevron-right"></i>
-              </a>
-            </li>
-          {{ end }}
-        </ul>
-      </nav>
-    {{ end }}
+    {{ partial "pagination.html" (dict "paginator" .Paginator) }}
   </div>
 </section>
 {{ end }}


### PR DESCRIPTION
## Summary

- Long page lists in production rendered every page number (60+ on the directory). Pagination now shows **first 2, last 2, and current ±1** with `…` fillers, while lists with ≤5 pages render unchanged.
- Extract the pagination markup into a single partial (`partials/pagination.html`) reused by `directory/list.html`, `post/list.html`, and `_default/list.html`.
- Fix a dark-mode contrast bug where `.page-link:hover` was applying near-white `bg-light` on the dark surface — now uses `var(--color-raised)`.

## Test plan

- [ ] `hugo build` succeeds
- [ ] Visit any paginated list (e.g. `/blog/`) — pagination renders as before
- [ ] Visit `/directory/` on a build with many entries — only first 2, last 2, and current ±1 show, with `…` between
- [ ] Hover a page link in light mode — purple text + lift
- [ ] Hover a page link in dark mode — pill background uses raised surface (not white)
- [ ] Directory filter view still hides pagination via the `#directory-pagination` id

🤖 Generated with [Claude Code](https://claude.com/claude-code)