### PR TITLE
Run non-production build on same-repo PRs with main-data fallback

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -13,9 +13,12 @@ on:
       triggering_repo:
         description: "Triggering repo"
         required: false
+  pull_request:
+    branches:
+      - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.directory }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.directory || 'pr' }}
   cancel-in-progress: true
 
 env:
@@ -29,6 +32,7 @@ env:
 jobs:
   build:
     name: Build site
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -59,7 +63,7 @@ jobs:
 
       - name: Site data - DIRECTORY - Get
         uses: actions/checkout@v6
-        if: ${{ (env.on_fork != 'true') && env.directory == 'main' }}
+        if: ${{ env.on_fork != 'true' }}
         with:
           repository: rladies/directory
           ssh-key: ${{ secrets.ssh_directoryy_repo }}
@@ -74,19 +78,19 @@ jobs:
           run_id: ${{ env.directory }}
           repo: rladies/directory
           path: entries/
+          if_no_artifact_found: warn
 
       - name: Site data - DIRECTORY - Move
         if: ${{ env.on_fork != 'true' }}
         run: |
-          rm -rf data/directory/* assets/directory/*
-          if [ "${{ env.directory }}" = "main" ]; then
-            cp -r tmpd/dir/data/json data/directory
-            cp -r tmpd/dir/data/img/* assets/directory
-          else
-            cp -r entries/json data/directory
-            if [ -d "entries/img" ]; then
-              cp -r entries/img/* assets/directory/
-            fi
+          rm -rf data/directory assets/directory/*
+          cp -r tmpd/dir/data/json data/directory
+          cp -r tmpd/dir/data/img/* assets/directory/
+          if [ -d entries/json ] && [ -n "$(ls -A entries/json 2>/dev/null)" ]; then
+            cp -r entries/json/* data/directory/
+          fi
+          if [ -d entries/img ] && [ -n "$(ls -A entries/img 2>/dev/null)" ]; then
+            cp -r entries/img/* assets/directory/
           fi
 
       - name: Site data - clean cloned repos


### PR DESCRIPTION
## Summary

- Add `pull_request` trigger to `build-preview.yaml` (non-fork branches only) so the preview build runs on internal PRs and we can verify the full site build before merging.
- Always seed directory data from `rladies/directory@main` and overlay the upstream `entries` artifact only when present. A missing/empty artifact no longer fails the build.
- Set `if_no_artifact_found: warn` on the artifact download so workflow_dispatch from `rladies/directory` survives an empty upstream artifact.

## Context

Recent non-production runs have been failing with a 404 on artifact download. Root cause is upstream: `airtable-update.yml` in `rladies/directory` has been failing since 2026-05-01, so `retrigger-website.yml` uploads an empty `entries` artifact, and this workflow then 404s trying to fetch it. Those upstream fixes still need to happen in `rladies/directory`, but this change makes the non-prod build resilient to it.

## Test plan

- [ ] This PR itself triggers the new `pull_request` flow — verify `Build and deploy non-production` runs and produces a Netlify preview at `dmain-r<PR#>--rladies-dev.netlify.app`.
- [ ] PR gets a preview comment.
- [ ] Existing `workflow_dispatch` path from `rladies/directory` still works when the upstream artifact is missing (build falls back to main data).
- [ ] Fork PRs continue to skip the job (no secrets exposure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)