### PR TITLE
Auto-assign new issues to @rladies/website team

### DIFF
--- a/.github/workflows/auto-assign-issues.yaml
+++ b/.github/workflows/auto-assign-issues.yaml
@@ -1,0 +1,21 @@
+name: Auto-assign issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign a website team member
+        uses: pozil/auto-assign-issue@v2
+        with:
+          repo-token: ${{ secrets.ADMIN_TOKEN }}
+          teams: website
+          numOfAssigneesPerTeam: 1
+          allowSelfAssign: true
+          abortIfPreviousAssignees: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/auto-assign-issues.yaml` that fires on `issues: opened` and assigns one random member of `@rladies/website` via [pozil/auto-assign-issue](https://github.com/pozil/auto-assign-issue).
- `abortIfPreviousAssignees: true` skips the issue if it already has an assignee (e.g., self-assigned at creation).
- Uses `secrets.ADMIN_TOKEN` because the default `GITHUB_TOKEN` cannot read team membership — the action needs a token with `read:org`.

## Test plan
- [ ] Confirm `ADMIN_TOKEN` has `read:org` scope (used elsewhere in `global-team.yml`, so likely fine — flag if not).
- [ ] Open a test issue after merge and verify a website-team member is auto-assigned.
- [ ] Open a test issue with a manual assignee and confirm the workflow skips it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)