### PR TITLE
Reduce crawlability of /directory member pages

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-
-Disallow: /directory/
-Disallow: /images/directory

--- a/themes/hugo-rladiesplus/layouts/partials/funcs/directory/card.html
+++ b/themes/hugo-rladiesplus/layouts/partials/funcs/directory/card.html
@@ -1,12 +1,6 @@
 {{ $dir := newScratch }}
 {{ $dir.Set "shuffle" slice }}
-{{ $dir.Set "title" .data.Title }} 
-{{ $dir.Add "title" "<span><small>"}}
-{{ with .data.Params.social_media }}
-  {{ $some := partial "social_media.html" (dict "data" . ) }}
-  {{ $dir.Add "title" $some }} 
-{{ end }}
-{{ $dir.Add "title" "</small></span>"}}
+{{ $dir.Set "title" .data.Title }}
 
 {{ $dir.Set "subtitle" (printf "<p class=\"visually-hidden directory-id\">%s</p>" .name) }} 
 {{ with .data.Params.work.title }} 

--- a/themes/hugo-rladiesplus/layouts/partials/head/meta.html
+++ b/themes/hugo-rladiesplus/layouts/partials/head/meta.html
@@ -1,6 +1,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+{{ if and (eq .Section "directory") (eq .Kind "page") }}
+<meta name="robots" content="noindex, nofollow, noarchive">
+{{ end }}
+
 {{ $desc := or .Description .Params.summary .Site.Params.description }}
 {{ $title := .Title | markdownify | plainify }}
 {{ $siteTitle := .Site.Title | markdownify | plainify }}

--- a/themes/hugo-rladiesplus/layouts/robots.txt
+++ b/themes/hugo-rladiesplus/layouts/robots.txt
@@ -1,3 +1,49 @@
 User-agent: *
-
+Allow: /directory/$
 Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: GPTBot
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: ClaudeBot
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: anthropic-ai
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: Google-Extended
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: CCBot
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: PerplexityBot
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: Bytespider
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: Amazonbot
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory
+
+User-agent: cohere-ai
+Allow: /directory/$
+Disallow: /directory/
+Disallow: /images/directory


### PR DESCRIPTION
## Summary
- Adds robots rules (Hugo-rendered `layouts/robots.txt`) that allow only `/directory/` itself, blocking individual member pages and `/images/directory` for generic crawlers plus known AI scrapers (GPTBot, ClaudeBot, anthropic-ai, Google-Extended, CCBot, PerplexityBot, Bytespider, Amazonbot, cohere-ai).
- Adds `<meta name="robots" content="noindex, nofollow, noarchive">` on individual directory pages.
- Removes social-media icons from directory list cards (still shown on each member's own page). This reduces what a single listing page (or its JSON sibling) exposes about members, so even if the directory page is crawled, handles aren't bulk-extractable.
- Deletes the old `static/robots.txt` (superseded by the rendered template).

## Test plan
- [x] Visit `/directory/` and confirm member cards no longer show social-media icons.
- [x] Visit an individual `/directory/<member>/` page and confirm socials are still there.
- [x] View source on a member page and confirm `<meta name="robots" content="noindex, nofollow, noarchive">`.
- [x] Curl `/robots.txt` on the deployed site and verify the new disallow rules render.
- [x] Confirm `/directory/index.json` still drives the client-side filter (cards inside JSON now also have no socials).

🤖 Generated with [Claude Code](https://claude.com/claude-code)