### PR TITLE
Switch from PATs to Jinx GitHub App

### DIFF
--- a/.github/workflows/build-preview.yaml
+++ b/.github/workflows/build-preview.yaml
@@ -36,6 +36,14 @@ jobs:
         with:
           fetch-depth: 2
 
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Set env parameters
         run: |
           ver=$(cat .hugoversion)
@@ -43,10 +51,7 @@ jobs:
           echo "repo_owner=$(dirname ${{ env.repo_name }})" >> $GITHUB_ENV
           echo "repo_name=$(basename ${{ env.repo_name }})" >> $GITHUB_ENV
           echo "netalias=d${{ env.directory }}-r${{ env.rid}}" >> $GITHUB_ENV
-          echo "token=${{ secrets.GITHUB_TOKEN }}" >> $GITHUB_ENV
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "token=${{ secrets.GLOBAL_GHA_PAT }}" >> $GITHUB_ENV
-          fi
+          echo "token=${{ steps.app-token.outputs.token }}" >> $GITHUB_ENV
 
       - name: Install cURL Headers
         run: |
@@ -70,7 +75,7 @@ jobs:
         if: ${{ (env.on_fork != 'true') && env.directory != 'main' }}
         with:
           name: entries
-          github_token: ${{ secrets.GLOBAL_GHA_PAT }}
+          github_token: ${{ steps.app-token.outputs.token }}
           run_id: ${{ env.directory }}
           repo: rladies/directory
           path: entries/

--- a/.github/workflows/global-team.yml
+++ b/.github/workflows/global-team.yml
@@ -18,10 +18,18 @@ jobs:
     name: Retrieve Airtable data
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ssh-key: ${{ secrets.push-to-protected }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Install cURL Headers
         run: |
@@ -41,22 +49,15 @@ jobs:
           AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
         run: Rscript scripts/get_global_team.R
 
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Commit Changes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git add content/about-us/global-team/img
-          git add data/global_team
-          git commit -m "Automated update: Update Global Team"  || echo "No new data to commit"
-
-      - name: Pushing to the protected branch 'main'
-        uses: CasperWA/push-protected@v2
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.ADMIN_TOKEN }}
-          branch: main
-          unprotect_reviews: true
+          token: ${{ steps.app-token.outputs.token }}
+          add-paths: |
+            content/about-us/global-team/img
+            data/global_team
+          commit-message: "Automated update: Update Global Team"
+          branch: automated/global-team-update
+          title: "Automated update: Update Global Team"
+          body: "Weekly automated update of Global Team data from Airtable."
+          labels: automated

--- a/.github/workflows/hello.yaml
+++ b/.github/workflows/hello.yaml
@@ -10,6 +10,14 @@ jobs:
     if: github.event.action == 'opened'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
+
       - name: Get author
         id: author
         run: |
@@ -23,6 +31,7 @@ jobs:
         id: check
         env:
           AUTHOR: ${{ steps.author.outputs.login }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           if [[ "$AUTHOR" == *"[bot]" ]]; then
             echo "say_hello=false" >> $GITHUB_OUTPUT
@@ -31,7 +40,7 @@ jobs:
 
           status=$(curl -sg \
             -o /dev/null -w "%{http_code}" \
-            -H "Authorization: Bearer ${{ secrets.GLOBAL_GHA_PAT }}" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/orgs/rladies/teams/global/memberships/$AUTHOR")
 

--- a/.github/workflows/merge-pending.yaml
+++ b/.github/workflows/merge-pending.yaml
@@ -19,16 +19,21 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Setup GitHub CLI
-        run: |
-          echo "${{ secrets.ADMIN_TOKEN }}" | gh auth login --with-token
-          gh config set prompt-enabled false
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.JINX_APP_ID }}
+          private-key: ${{ secrets.JINX_PRIVATE_KEY }}
+          owner: rladies
 
       - name: Get current date for comparison
         id: get_date
         run: echo "CURRENT_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: Find and Process PRs with "pending" label
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           PR_NUMBERS=$(gh pr list --label "pending" --state "open" --json number,title,isDraft -q '.[] | select(.isDraft == false) | .number')
 


### PR DESCRIPTION
## Summary
- Replace `GLOBAL_GHA_PAT`, `ADMIN_TOKEN`, and `push-to-protected` SSH key with `actions/create-github-app-token`
- Convert `global-team.yml` from `CasperWA/push-protected` (requires admin) to `peter-evans/create-pull-request` (creates a mergeable PR instead)
- Affected workflows: build-preview, hello, merge-pending, global-team

## Test plan
- [ ] Trigger `build-preview` via workflow_dispatch and verify cross-repo artifact download works
- [ ] Open a PR/issue and verify the hello bot greets non-team members
- [ ] Verify `merge-pending` can find and merge pending-labeled PRs
- [ ] Trigger `global-team` and verify it creates a PR with Airtable data (instead of direct push to main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)