### PR TITLE
Emit article date meta tags on all pages

### DIFF
--- a/themes/hugo-rladiesplus/layouts/partials/head/meta.html
+++ b/themes/hugo-rladiesplus/layouts/partials/head/meta.html
@@ -71,9 +71,9 @@
 {{ with $ogWidth }}<meta property="og:image:width" content="{{ . }}">{{ end }}
 {{ with $ogHeight }}<meta property="og:image:height" content="{{ . }}">{{ end }}
 
+{{ with .Date }}<meta property="article:published_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}">{{ end }}
+{{ with .Lastmod }}<meta property="article:modified_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}">{{ end }}
 {{ if eq .Section "blog" | or (eq .Section "news") }}
-  {{ with .Date }}<meta property="article:published_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}">{{ end }}
-  {{ with .Lastmod }}<meta property="article:modified_time" content="{{ .Format "2006-01-02T15:04:05Z07:00" }}">{{ end }}
   {{ range .Params.authors }}<meta property="article:author" content="{{ .name }}">{{ end }}
   {{ range .Params.tags }}<meta property="article:tag" content="{{ . }}">{{ end }}
 {{ end }}


### PR DESCRIPTION
## Summary

- Move `article:published_time` / `article:modified_time` emission outside the `if eq .Section "blog" | or (eq .Section "news")` guard in [themes/hugo-rladiesplus/layouts/partials/head/meta.html](themes/hugo-rladiesplus/layouts/partials/head/meta.html) so every page (home, /about-us/, /coc/, /chapters/, etc.) exposes its `.Date` and `.Lastmod`.
- Article-specific tags (`article:author`, `article:tag`) stay scoped to blog/news where they make sense.

## Why

The Jinx RAG indexer reads these meta tags to weight chunks by both content age (when the info dates from) and maintenance freshness (when the page was last touched in git — `enableGitInfo: true` is already on). Until now, non-blog pages landed in the vector index with no date signal at all, so Jinx had no way to rank a recently-edited chapter guide above a five-year-old one with the same cosine similarity.

This is a meta-tag-only change; nothing visible to readers.

## Verification

Built locally and confirmed the homepage now emits `<meta property="article:modified_time" content="..."> ` (sourced from git lastmod via `enableGitInfo: true`).

Companion changes:
- rladies/jinx#63 — reranker-side change that consumes this signal.
- A matching custom-layout PR for rladies/rladiesguide (relearn-theme override).