### PR TITLE
Add package count stat card to packages page

### DIFF
--- a/themes/hugo-rladiesplus/layouts/packages/single.html
+++ b/themes/hugo-rladiesplus/layouts/packages/single.html
@@ -12,8 +12,16 @@
 
 <section class="site-section-lg">
   <div class="site-container">
-    <div class="max-w-3xl mx-auto mb-12 entry-content">
+    <div class="max-w-3xl mx-auto mb-10 entry-content">
       {{ .Content }}
+    </div>
+
+    <div class="max-w-sm mx-auto mb-12 fade-in-up">
+      <div class="stat-card">
+        <div class="stat-icon"><i class="fa-solid fa-cube"></i></div>
+        <p class="stat-number count" data-count="{{ len $packages }}">0</p>
+        <p class="stat-label">{{ i18n "r_packages" | default "R Packages" }}</p>
+      </div>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Adds a stat-card counter at the top of `/programs/packages/` showing the total number of community packages, using the existing animated counter pattern (`.count` + `data-count`) from `counter.js`
- Matches the visual style of the home impact stats and the directory page counter
- Uses the existing `r_packages` i18n key (translated in en/es/fr/pt)

## Test plan
- [x] Visit `/programs/packages/` and confirm the stat card appears above the hex wall
- [x] Confirm the number animates from 0 to the package total on scroll
- [x] Verify dark mode rendering
- [x] Spot-check other languages (`/es/`, `/fr/`, `/pt/`) for label translation

🤖 Generated with [Claude Code](https://claude.com/claude-code)